### PR TITLE
Add update command to main function for workspace installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,22 +42,23 @@ jobs:
           sudo chmod +x bump.sh
           VERSION=$(sed -n 's/.*\.version = "\([0-9]\.[0-9]\.[0-9]\)".*/\1/p' build.zig.zon)
           echo "Current version: $VERSION"
-          if [ "${{ github.event_name }}" == 'workflow_dispatch' ]; then
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             INCREMENT="${{ github.event.inputs.version }}"
           else
             INCREMENT="p"
-            PR_CONTENT="${{ github.event.pull_request.title }} ${{ github.event.pull_request.body }}"
-            if echo "$PR_CONTENT" | grep -qi '\[major\]'; then
+            if [[ "${{ github.event.pull_request.title }} ${{ github.event.pull_request.body }}" =~ \[major\] ]]; then
               INCREMENT="M"
-            elif echo "$PR_CONTENT" | grep -qi '\[minor\]'; then
+            elif [[ "${{ github.event.pull_request.title }} ${{ github.event.pull_request.body }}" =~ \[minor\] ]]; then
               INCREMENT="m"
             fi
           fi
+          echo "Determined increment: $INCREMENT"
           VERSION=$(./bump.sh -$INCREMENT $VERSION)
           if [ $? -ne 0 ]; then
             echo "Failed to bump version"
             exit 1
           fi
+          echo "New version: $VERSION"
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the `release.yml` workflow and the `main.zig` file to improve version bumping and add an update command. The most important changes include modifying the version increment logic and adding a new update command for different operating systems.

Improvements to version bumping:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L45-R61): Changed the version increment logic to use pattern matching for determining the increment type from the pull request content. Added debug echo statements to output the determined increment and new version.

Addition of update command:

* [`src/main.zig`](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730R146-R177): Added a new `.update` command to the main function, which runs platform-specific commands to update the workspace. This includes handling both Windows and non-Windows systems and logging the update results.